### PR TITLE
Support https requests without certificate authentication

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -40,8 +40,8 @@ parser.addArgument(
 );
 parser.addArgument(
   [ '--endpoint' ],
-  { help: 'Endpoint for the Performance Analyzer queries. ' +
-  'This can also be defined in the JSON.' }
+  { help: 'Endpoint URL for the Performance Analyzer queries. This can also be defined in the JSON. ' +
+  'Protocol is "http" by default, unless "https" specified in the URL.' }
 );
 parser.addArgument(
   [ '--nodename' ],

--- a/lib/perf-top/util/generate-data.js
+++ b/lib/perf-top/util/generate-data.js
@@ -14,10 +14,11 @@
  */
 
 var http = require('http');
+var https = require('https');
 var url = require('url');
 
 /**
- * Makes a HTTP request to "{endpoint}/_opendistro/_performanceanalyzer/metrics?metrics=${metrics}&agg=${aggregates}&dim=${dimensions}&nodes=all"
+ * Makes a HTTP(S) request to "{endpoint}/_opendistro/_performanceanalyzer/metrics?metrics=${metrics}&agg=${aggregates}&dim=${dimensions}&nodes=all"
  * and parses the response to a hashmap object.
  *
  * @param {string} endpoint - endpoint for the metric query.
@@ -31,8 +32,9 @@ function getMetricData (endpoint, metrics, aggregates, dimensions, done) {
   var aggParam = (aggregates) ? `&agg=${aggregates}` : '&agg=';
   var dimParam = (dimensions) ? `&dim=${dimensions}` : '&dim=';
 
-  var httpOptions = getHttpURLOptions(endpoint, `/_opendistro/_performanceanalyzer/metrics?${metricParam}${aggParam}${dimParam}&nodes=all`);
-  makeHttpRequest(httpOptions, function (response) {
+  var urlOptions = getURLOptions(endpoint, `/_opendistro/_performanceanalyzer/metrics?${metricParam}${aggParam}${dimParam}&nodes=all`);
+
+  makeRequest(urlOptions, function (response) {
     if (response === '') {
       done({});
     } else {
@@ -42,28 +44,29 @@ function getMetricData (endpoint, metrics, aggregates, dimensions, done) {
 }
 
 /**
- * Gets a URL option with host, port (default = 80), and path for http.request().
+ * Gets a URL option with host, port (default = 80), and path for http(s).request().
  *
  * @param {string} endpoint - endpoint for the query.
  * @param {string} path - metric query request path.
  */
-function getHttpURLOptions (endpoint, path) {
-  endpoint = endpoint.startsWith('http://') ? endpoint : 'http://' + endpoint;
-  var httpURL = url.parse(url.resolve(endpoint, path));
+function getURLOptions (endpoint, path) {
+  endpoint = ( endpoint.startsWith('http://') || endpoint.startsWith('https://') ) ? endpoint : 'http://' + endpoint;
+  var parsedURL = url.parse(url.resolve(endpoint, path));
   return {
-    host: httpURL.hostname,
-    port: (httpURL.port === null) ? 80 : httpURL.port,
-    path: httpURL.path
+    protocol: parsedURL.protocol,
+    host: parsedURL.hostname,
+    port: (parsedURL.port === null) ? 80 : parsedURL.port,
+    path: parsedURL.path
   };
 }
 
 /**
- * Makes a HTTP request and returns the response.
+ * Makes a HTTP(S) request and returns the response.
  *
- * @param {string} httpOptions - URL option for the HTTP request.
- * @param {string} done - callback for the HTTP response.
+ * @param {string} urlOptions - URL option for the HTTP(S) request.
+ * @param {string} done - callback for the HTTP(S) response.
  */
-function makeHttpRequest (httpOptions, done) {
+function makeRequest (urlOptions, done) {
   var rawData = '';
   var respond = function (response) {
     response.on('data', function (chunk) {
@@ -73,8 +76,13 @@ function makeHttpRequest (httpOptions, done) {
       done(rawData);
     });
   };
-
-  var req = http.request(httpOptions, respond);
+  var protocol = http;
+  if (urlOptions.protocol == "https:") {
+    protocol = https;
+    urlOptions.rejectUnauthorized = false;
+  }
+  var protocol = (urlOptions.protocol == "https:") ? https : http;
+  var req = protocol.request(urlOptions, respond);
   req.on('error', function (error) {
     console.error(error);
     done('');
@@ -83,29 +91,29 @@ function makeHttpRequest (httpOptions, done) {
 }
 
 /**
- * Makes a HTTP request to "{endpoint}/_opendistro/_performanceanalyzer/metrics/units"
+ * Makes a HTTP(S) request to "{endpoint}/_opendistro/_performanceanalyzer/metrics/units"
  * and parses the response to a hashmap object.
  *
  * @param {string} endpoint - endpoint for the query.
- * @param {string} done - callback for the HTTP response.
+ * @param {string} done - callback for the HTTP(S) response.
  */
 function getMetricUnits (endpoint, done) {
-  var httpOptions = getHttpURLOptions(endpoint, '/_opendistro/_performanceanalyzer/metrics/units');
-  makeHttpRequest(httpOptions, function (response) {
+  var urlOptions = getURLOptions(endpoint, '/_opendistro/_performanceanalyzer/metrics/units');
+  makeRequest(urlOptions, function (response) {
     if (response === '') {
-      console.error('Failed to retrieve units for metrics. HTTP response was empty.');
+      console.error('Failed to retrieve units for metrics. HTTP(S) response was empty.');
       done({});
     }
     try {
       var jsonData = JSON.parse(response);
       if (Object.keys(jsonData).length === 1 && 'error' in jsonData) {
-        console.error(`Failed to retrieve units for metrics. HTTP response was:
+        console.error(`Failed to retrieve units for metrics. HTTP(S) response was:
           ${response}`);
         done({});
       }
       done(jsonData);
     } catch (e) {
-      console.error(`HTTP Response for metricUnits was not in JSON format:
+      console.error(`HTTP(S) Response for metricUnits was not in JSON format:
         ${response}`);
       done({});
     }
@@ -156,7 +164,7 @@ function sortDataByDecreasingOrder (dimensions, data, sortBy) {
  * @param {Array} data - 2D array to modify.
  */
 function addCommaDelimiter (data) {
-  if (data.length == 0) {
+  if (data.length === 0) {
     return;
   }
   var numColumn = data[0].length;
@@ -208,9 +216,9 @@ function aggregateMetricData (metricData) {
 }
 
 /**
- * Given a string HTTP response, parse and return the data into a hashmap
+ * Given a string HTTP(S) response, parse and return the data into a hashmap
  *
- * @param {object} rawData - string response from the HTTP request that can be parsed into a JSON object.
+ * @param {object} rawData - string response from the HTTP(S) request that can be parsed into a JSON object.
  * @returns {object} - returns a hashmap in the format of
  *                     { nodeName1: { fields: [dim1, dim2, ...] ,
  *                                   data: [[data], [data], ...],
@@ -224,12 +232,12 @@ function getDataPerNode (rawData) {
   try {
     jsonData = JSON.parse(rawData);
     if (Object.keys(jsonData).length === 1 && 'error' in jsonData) {
-      console.error(`Failed to retrieve data for metrics. HTTP response was:
+      console.error(`Failed to retrieve data for metrics. HTTP(S) response was:
         ${rawData}`);
       return {};
     }
   } catch (e) {
-    console.error(`HTTP Response for per-node data was not in JSON format:
+    console.error(`HTTP(S) Response for per-node data was not in JSON format:
       ${rawData}`);
     return {};
   }

--- a/lib/perf-top/util/generate-data.js
+++ b/lib/perf-top/util/generate-data.js
@@ -76,13 +76,12 @@ function makeRequest (urlOptions, done) {
       done(rawData);
     });
   };
-  var protocol = http;
+  var client = http;
   if (urlOptions.protocol == "https:") {
-    protocol = https;
+    client = https;
     urlOptions.rejectUnauthorized = false;
   }
-  var protocol = (urlOptions.protocol == "https:") ? https : http;
-  var req = protocol.request(urlOptions, respond);
+  var req = client.request(urlOptions, respond);
   req.on('error', function (error) {
     console.error(error);
     done('');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build-linux": "./node_modules/.bin/pkg . --targets linux --output ./build/perf-top-linux",
     "build-macos": "./node_modules/.bin/pkg . --targets macos --output ./build/perf-top-macos",
     "clean": "rm -rf ./build 2>/dev/null || true && rm -rf ./node_modules",
-    "lint": "./node_modules/.bin/eslint perf-top/ bin.js",
+    "lint": "./node_modules/.bin/eslint lib/perf-top/ lib/bin.js bin/global.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Sample command for endpoint with HTTPS protocol:
`./perf-top-linux --dashboard NodeAnalysis --endpoint https://localhost:9600`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
