### PR TITLE
Update PerfTop to support OpenDistro 1.2 releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        es_version = System.getProperty("es.version", "6.5.4")
+        es_version = System.getProperty("es.version", "7.2.0")
     }
     // This isn't applying from repositories.gradle so repeating it here
     repositories {
@@ -24,7 +24,7 @@ node {
 }
 
 ext {
-    opendistroVersion = '1.1.0'
+    opendistroVersion = '1.2.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     isLinux = "true" == System.getProperty("build.linux", "false")
     isMacOS = "true" == System.getProperty("build.macos", "false")
@@ -107,4 +107,7 @@ bundlePlugin {
     }
 }
 
-gradle.startParameter.excludedTaskNames += ["integTestCluster#wait", "integTestRunner"]
+// The testingConventions task now mandates atleast one of the integ test tasks to be performed.
+// Since perftop is not really a plugin on its own, it fails the plugin install step during the integ tests. So, 
+// skip running testingConventions task.
+gradle.startParameter.excludedTaskNames += ["integTestCluster#wait", "integTestRunner", "testingConventions"]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,7 +313,6 @@
         "drawille-canvas-blessed-contrib": ">=0.1.3",
         "lodash": "~>=4.17.11",
         "map-canvas": ">=0.1.5",
-        "marked": "^0.6.2",
         "marked-terminal": "^1.5.0",
         "memory-streams": "^0.1.0",
         "memorystream": "^0.3.1",
@@ -322,6 +321,13 @@
         "strip-ansi": "^3.0.0",
         "term-canvas": "0.0.5",
         "x256": ">=0.0.1"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+        }
       }
     },
     "brace-expansion": {
@@ -2090,11 +2096,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
-      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA=="
     },
     "marked-terminal": {
       "version": "1.7.0",

--- a/release-notes
+++ b/release-notes
@@ -1,3 +1,6 @@
+## Version 1.2.0 (Current)
+This is release of the Open Distro PerfTop, which is compatible with Open Distro Performance Analyzer 1.2.
+
 ## Version 1.1.0 (Current)
 This is release of the Open Distro PerfTop, which is compatible with Open Distro Performance Analyzer 1.1.
 


### PR DESCRIPTION
*Description of changes:*
1. Updating the open distro version number for Perftop to 1.2.0
1. Bumping up the es-version compatibility
1. Updating the gradle version to support the ElasticSearch version 7.2.0
1. Updating the release notes/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
