### PR TITLE
Add support to pass basic-auth in endpoint url 

### DIFF
--- a/lib/perf-top/util/generate-data.js
+++ b/lib/perf-top/util/generate-data.js
@@ -55,7 +55,8 @@ function getURLOptions (endpoint, path) {
   return {
     protocol: parsedURL.protocol,
     host: parsedURL.hostname,
-    port: (parsedURL.port === null) ? 80 : parsedURL.port,
+    auth: parsedURL.auth,
+    port: (parsedURL.port === null) ? (parsedURL.protocol === 'https:' ? 443 : 80 ): parsedURL.port,
     path: parsedURL.path
   };
 }


### PR DESCRIPTION
* Issue #34
* user can pass basic auth credentials in the endpoint

example :
```
perf-top --endpoint https://username:password@cluster_endpoint --dashboard ClusterOverview

```

* By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
