### PR TITLE
Use Java 12 in CD workflow for master

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
 
-    - name: Set up JDK 13
+    - name: Set up JDK 12
       uses: actions/setup-java@v1
       with:
-        java-version: 13.0.x
+        java-version: 12.0.x
 
     - name: Set up Node JS
       uses: actions/setup-node@v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Using Java 12 fixes the CD workflow on master.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
