### PR TITLE
Change CD workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,12 @@
 name: CD
 
 on:
+  # push:
+  #   tags:
+  #     - 'v*'
   push:
-    tags:
-      - 'v*'
+    branches:
+      - "release-workflow-patch"
 
 jobs:
   build:
@@ -38,19 +41,29 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: Upload Artifacts to S3
       run: |
-        s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-        aws s3 cp artifacts/*MACOS*.zip $s3_path/perftop/
-        aws s3 cp artifacts/*LINUX*.zip $s3_path/perftop/
-        aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/downloads/*"
+        macos=`ls artifacts/*MACOS*.zip`
+        linux=`ls artifacts/*LINUX*.zip`
 
-    - name: Upload Workflow Artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: artifacts
-        path: artifacts/
+        # Inject the build number before the suffix
+        macos_outfile=`basename ${macos%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+        linux_outfile=`basename ${linux%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+
+        s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-clients/perftop/"
+
+        echo "Copying ${macos} to ${s3_prefix}${macos_outfile}"
+        aws s3 cp --quiet $macos ${s3_prefix}${macos_outfile}
+
+        echo "Copying ${linux} to ${s3_prefix}${linux_outfile}"
+        aws s3 cp --quiet $linux ${s3_prefix}${linux_outfile}
+
+    # - name: Upload Workflow Artifacts
+    #   uses: actions/upload-artifact@v1
+    #   with:
+    #     name: artifacts
+    #     path: artifacts/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,9 @@
 name: CD
 
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -47,8 +44,8 @@ jobs:
 
     - name: Upload Artifacts to S3
       run: |
-        macos=`ls artifacts/*MACOS*.zip`
-        linux=`ls artifacts/*LINUX*.zip`
+        macos=`ls artifacts/*macos*.zip`
+        linux=`ls artifacts/*linux*.zip`
 
         # Inject the build number before the suffix
         macos_outfile=`basename ${macos%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
@@ -62,8 +59,8 @@ jobs:
         echo "Copying ${linux} to ${s3_prefix}${linux_outfile}"
         aws s3 cp --quiet $linux ${s3_prefix}${linux_outfile}
 
-    # - name: Upload Workflow Artifacts
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: artifacts
-    #     path: artifacts/
+    - name: Upload Workflow Artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: artifacts
+        path: artifacts/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations. This PR changes the CD workflow to add a build number and write the zip artifact to staging.artifacts.opendistroforelasticsearch.amazon.com.

*To Dos:* Please follow naming convention guidelines to rename the artifact so that this PR works as expected. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
