### PR TITLE
Update the Perftop Package with new naming Convention for ODFE

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ Supported platforms: Linux, macOS
 
 npm:
 ```bash
-perf-top --dashboard NodeAnalysis
+opendistro-perf-top --dashboard NodeAnalysis
 ```
 Excutables:
 
 ```
-./perf-top-${PLATFORM} --dashboard $JSON --endpoint $ENDPOINT
+./opendistro-perf-top-${PLATFORM} --dashboard $JSON --endpoint $ENDPOINT
 ```
 
 ## Build
@@ -97,7 +97,7 @@ Prerequisites:
 1. Clone/download from Github
 2. Run `./gradlew build -Dbuild.linux={true/false} -Dbuild.macos={true/false}`. This will run the following:
    1. `npm install` - locally installs dependencies
-   2. `npm run build-{linux/macos}` - creates "perf-top-{linux/macos}" executables.
+   2. `npm run build-{linux/macos}` - creates "opendistro-perf-top-{linux/macos}" executables.
 3. For cleaning, run `./gradlew clean` which will run:
    1. `npm run clean` - deletes locally installed dependencies and executables
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,10 @@ ext {
 group = "com.amazon.opendistroforelasticsearch"
 version = "${opendistroVersion}.0"
 if (isLinux) {
-    version += "-LINUX"
+    version += "-linux-x64"
 }
 if (isMacOS) {
-    version += "-MACOS"
+    version += "-macos-x64"
 }
 if (isSnapshot) {
     version += "-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -82,23 +82,23 @@ clean {
 // We are excluding plugin descriptor for PerfTop
 // The info here could be random
 esplugin {
-    name 'perf-top'
+    name 'opendistro-perf-top'
     description 'PerfTop'
     classname 'com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerPlugin'
 }
 
 
 bundlePlugin {
-    exclude "perf-top*.jar"
+    exclude "opendistro-perf-top*.jar"
     exclude "plugin-descriptor.properties"
     if (isLinux) {
         from ("build/") {
-            include "perf-top-linux"
+            include "opendistro-perf-top-linux"
         }
     }
     if (isMacOS) {
         from ("build/") {
-            include "perf-top-macos"
+            include "opendistro-perf-top-macos"
         }
     }
     from ("dashboards/") {

--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "PerfTop CLI tool for Open Distro Performance Analyzer",
   "author": "Amazon Web Services",
   "bin": {
-    "perf-top": "./bin/global.js"
+    "opendistro-perf-top": "./bin/global.js"
   },
   "preferGlobal": "true",
   "scripts": {
-    "build-linux": "./node_modules/.bin/pkg . --targets linux --output ./build/perf-top-linux",
-    "build-macos": "./node_modules/.bin/pkg . --targets macos --output ./build/perf-top-macos",
+    "build-linux": "./node_modules/.bin/pkg . --targets linux --output ./build/opendistro-perf-top-linux",
+    "build-macos": "./node_modules/.bin/pkg . --targets macos --output ./build/opendistro-perf-top-macos",
     "clean": "rm -rf ./build 2>/dev/null || true && rm -rf ./node_modules",
-    "lint": "./node_modules/.bin/eslint lib/perf-top/ lib/bin.js bin/global.js",
+    "lint": "./node_modules/.bin/eslint lib/opendistro-perf-top/ lib/bin.js bin/global.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updated the naming Convention of the binaries for Linux and Mac with the latest naming convention for ODFE

*Testing:* 

```
aditjind@3c22fbd31611 perftop % ./gradlew build -Dbuild.linux=true -Dbuild.macos=true

> Configure project :

> pkg@4.4.9
> Warning Cannot resolve 'path.resolve(process.cwd(), args.dashboard)'
  /Users/aditjind/sifi_gh/perftop/lib/bin.js
  Dynamic require may fail at run time, because the requested file
  is unknown at compilation time and not included into executable.
  Use a string literal as an argument for 'require', or leave it
  as is and specify the resolved file name in 'scripts' option.

BUILD SUCCESSFUL in 17s
14 actionable tasks: 9 executed, 5 up-to-date
aditjind@3c22fbd31611 perftop % ./build/opendistro-perf-top-macos --dashboard ClusterOverview 
aditjind@3c22fbd31611 perftop % 

```


 In Progress, Will update the results. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
